### PR TITLE
Clarify that (only) STRICT is the default type

### DIFF
--- a/src/main/java/com/vdurmont/semver4j/Semver.java
+++ b/src/main/java/com/vdurmont/semver4j/Semver.java
@@ -522,7 +522,6 @@ public class Semver implements Comparable<Semver> {
         STRICT,
 
         /**
-         * The default type of version.
          * Major part is required.
          * Minor, patch, suffixes and build are optional.
          */


### PR DESCRIPTION
STRICT is the default used in the constructor.