### PR TITLE
Requirement: Replace build* methods that take a Semver with a single one

### DIFF
--- a/src/main/java/com/vdurmont/semver4j/Requirement.java
+++ b/src/main/java/com/vdurmont/semver4j/Requirement.java
@@ -54,10 +54,14 @@ public class Requirement {
     }
 
     /**
-     * @see #buildStrict(Semver)
+     * Builds a requirement (will test that the version is equivalent to the requirement)
+     *
+     * @param requirement the version of the requirement
+     *
+     * @return the generated requirement
      */
-    public static Requirement buildStrict(String requirement) {
-        return buildStrict(new Semver(requirement));
+    public static Requirement build(Semver requirement) {
+        return new Requirement(new Range(requirement, Range.RangeOperator.EQ), null, null, null);
     }
 
     /**
@@ -67,15 +71,8 @@ public class Requirement {
      *
      * @return the generated requirement
      */
-    public static Requirement buildStrict(Semver requirement) {
-        return new Requirement(new Range(requirement, Range.RangeOperator.EQ), null, null, null);
-    }
-
-    /**
-     * @see #buildLoose(Semver)
-     */
-    public static Requirement buildLoose(String requirement) {
-        return buildLoose(new Semver(requirement, Semver.SemverType.LOOSE));
+    public static Requirement buildStrict(String requirement) {
+        return build(new Semver(requirement));
     }
 
     /**
@@ -85,8 +82,8 @@ public class Requirement {
      *
      * @return the generated requirement
      */
-    public static Requirement buildLoose(Semver requirement) {
-        return new Requirement(new Range(requirement, Range.RangeOperator.EQ), null, null, null);
+    public static Requirement buildLoose(String requirement) {
+        return build(new Semver(requirement, Semver.SemverType.LOOSE));
     }
 
     /**


### PR DESCRIPTION
It is confusing to have build{Loose,Strict}() that take a Semver, as the
type is taken from the Semver in any case. In fact the bodies of these
methods were all the same. So replace them with a single build() method
that takes a Semver.