### PR TITLE
Fix comparing loosely built requirements

### DIFF
--- a/src/main/java/com/vdurmont/semver4j/Range.java
+++ b/src/main/java/com/vdurmont/semver4j/Range.java
@@ -15,7 +15,7 @@ public class Range {
     }
 
     public boolean isSatisfiedBy(String version) {
-        return this.isSatisfiedBy(new Semver(version));
+        return this.isSatisfiedBy(new Semver(version, this.version.getType()));
     }
 
     public boolean isSatisfiedBy(Semver version) {

--- a/src/main/java/com/vdurmont/semver4j/Semver.java
+++ b/src/main/java/com/vdurmont/semver4j/Semver.java
@@ -239,7 +239,7 @@ public class Semver implements Comparable<Semver> {
      * @see #isLowerThan(Semver)
      */
     public boolean isLowerThan(String version) {
-        return this.isLowerThan(new Semver(version));
+        return this.isLowerThan(new Semver(version, this.type));
     }
 
     /**
@@ -257,7 +257,7 @@ public class Semver implements Comparable<Semver> {
      * @see #isEquivalentTo(Semver)
      */
     public boolean isEquivalentTo(String version) {
-        return this.isEquivalentTo(new Semver(version));
+        return this.isEquivalentTo(new Semver(version, this.type));
     }
 
     /**
@@ -279,7 +279,7 @@ public class Semver implements Comparable<Semver> {
      * @see #isEqualTo(Semver)
      */
     public boolean isEqualTo(String version) {
-        return this.isEqualTo(new Semver(version));
+        return this.isEqualTo(new Semver(version, this.type));
     }
 
     /**
@@ -308,7 +308,7 @@ public class Semver implements Comparable<Semver> {
      * @see #diff(Semver)
      */
     public VersionDiff diff(String version) {
-        return this.diff(new Semver(version));
+        return this.diff(new Semver(version, this.type));
     }
 
     /**

--- a/src/test/java/com/vdurmont/semver4j/RequirementTest.java
+++ b/src/test/java/com/vdurmont/semver4j/RequirementTest.java
@@ -22,6 +22,12 @@ public class RequirementTest {
         assertIsRange(requirement, version, Range.RangeOperator.EQ);
     }
 
+    @Test public void buildLoose() {
+        String version = "0.27";
+        Requirement requirement = Requirement.buildLoose(version);
+        assertIsRange(requirement, version, Range.RangeOperator.EQ);
+    }
+
     @Test public void buildNPM_with_a_full_version() {
         String version = "1.2.3";
         Requirement requirement = Requirement.buildNPM(version);


### PR DESCRIPTION
When building from a string, use the type of the Semver to compare to.
Otherwise a Requirement created via buildLoose(String) would still be
compared strictly.