### PR TITLE
Requirement: Use the range's semver type, if any

### DIFF
--- a/src/main/java/com/vdurmont/semver4j/Requirement.java
+++ b/src/main/java/com/vdurmont/semver4j/Requirement.java
@@ -509,7 +509,11 @@ public class Requirement {
      * @see #isSatisfiedBy(Semver)
      */
     public boolean isSatisfiedBy(String version) {
-        return this.isSatisfiedBy(new Semver(version));
+        if (this.range != null) {
+            return this.isSatisfiedBy(new Semver(version, this.range.version.getType()));
+        } else {
+            return this.isSatisfiedBy(new Semver(version));
+        }
     }
 
     /**

--- a/src/test/java/com/vdurmont/semver4j/RequirementTest.java
+++ b/src/test/java/com/vdurmont/semver4j/RequirementTest.java
@@ -283,6 +283,14 @@ public class RequirementTest {
         assertIsRange(Requirement.buildIvy("(,2.0["), "2.0.0", Range.RangeOperator.LT);
     }
 
+    @Test public void isSatisfiedBy_with_a_loose_type() {
+        Requirement req = Requirement.buildLoose("1.3.2");
+
+        assertFalse(req.isSatisfiedBy("0.27"));
+        assertTrue(req.isSatisfiedBy("1.3.2"));
+        assertFalse(req.isSatisfiedBy("1.5"));
+    }
+
     @Test public void isSatisfiedBy_with_a_complex_example() {
         Requirement req = Requirement.buildNPM("1.x || >=2.5.0 || 5.0.0 - 7.2.3");
 


### PR DESCRIPTION
This fixes isSatisfiedBy() for loosely built requirements.