### PR TITLE
Fix Java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,10 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <testSource>1.6</testSource>
-                    <testTarget>1.6</testTarget>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <testSource>1.7</testSource>
+                    <testTarget>1.7</testTarget>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Two classes (`Semver` and `Requirements`) import `java.util.Objects` which was introduced in Java 7.