### PR TITLE
Pretty string representations for Range and Requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,10 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <testSource>1.6</testSource>
-                    <testTarget>1.6</testTarget>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <testSource>1.7</testSource>
+                    <testTarget>1.7</testTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/vdurmont/semver4j/Range.java
+++ b/src/main/java/com/vdurmont/semver4j/Range.java
@@ -36,33 +36,43 @@ public class Range {
     }
 
     @Override public String toString() {
-        return "(" + this.op + ", " + this.version + ")";
+        return this.op.asString() + this.version;
     }
 
     public enum RangeOperator {
         /**
          * The version and the requirement are equivalent
          */
-        EQ,
+        EQ("="),
 
         /**
          * The version is lower than the requirent
          */
-        LT,
+        LT("<"),
 
         /**
          * The version is lower than or equivalent to the requirement
          */
-        LTE,
+        LTE("<="),
 
         /**
          * The version is greater than the requirement
          */
-        GT,
+        GT(">"),
 
         /**
          * The version is greater than or equivalent to the requirement
          */
-        GTE
+        GTE(">=");
+
+        private final String s;
+
+        RangeOperator(String s) {
+            this.s = s;
+        }
+
+        public String asString() {
+            return s;
+        }
     }
 }

--- a/src/main/java/com/vdurmont/semver4j/Requirement.java
+++ b/src/main/java/com/vdurmont/semver4j/Requirement.java
@@ -1,12 +1,19 @@
 package com.vdurmont.semver4j;
 
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.vdurmont.semver4j.Semver.SemverType;
 import com.vdurmont.semver4j.Tokenizer.Token;
 import com.vdurmont.semver4j.Tokenizer.TokenType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Stack;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * A requirement will provide an easy way to check if a version is satisfying.
@@ -586,15 +593,25 @@ public class Requirement {
 
     @Override public String toString() {
         if (this.range != null) {
-            return "Requirement{" + this.range + "}";
+            return this.range.toString();
         }
-        return "Requirement{" + this.req1 + " " + this.op + " " + this.req2 + "}";
+        return this.req1 + " " + (this.op == RequirementOperator.OR ? this.op.asString() + " " : "") + this.req2;
     }
 
     /**
      * The operators that can be used in a requirement.
      */
     protected enum RequirementOperator {
-        AND, OR
+        AND(""), OR("||");
+
+        private final String s;
+
+        RequirementOperator(String s) {
+            this.s = s;
+        }
+
+        public String asString() {
+            return s;
+        }
     }
 }

--- a/src/test/java/com/vdurmont/semver4j/RangeTest.java
+++ b/src/test/java/com/vdurmont/semver4j/RangeTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -60,5 +61,13 @@ public class RangeTest {
         assertTrue(range.isSatisfiedBy("1.2.3"));
         assertFalse(range.isSatisfiedBy("1.2.2"));
         assertTrue(range.isSatisfiedBy("1.2.4"));
+    }
+
+    @Test public void prettyString() {
+        assertEquals("=1.2.3", new Range("1.2.3", Range.RangeOperator.EQ).toString());
+        assertEquals("<1.2.3", new Range("1.2.3", Range.RangeOperator.LT).toString());
+        assertEquals("<=1.2.3", new Range("1.2.3", Range.RangeOperator.LTE).toString());
+        assertEquals(">1.2.3", new Range("1.2.3", Range.RangeOperator.GT).toString());
+        assertEquals(">=1.2.3", new Range("1.2.3", Range.RangeOperator.GTE).toString());
     }
 }

--- a/src/test/java/com/vdurmont/semver4j/RequirementTest.java
+++ b/src/test/java/com/vdurmont/semver4j/RequirementTest.java
@@ -405,6 +405,34 @@ public class RequirementTest {
         assertTrue(req.range.version.isEquivalentTo("1.0.0"));
     }
 
+    @Test public void prettyString() {
+        assertEquals(">=0.0.0", Requirement.buildNPM("latest").toString());
+        assertEquals(">=0.0.0", Requirement.buildNPM("*").toString());
+        assertEquals(">=1.0.0 <2.0.0", Requirement.buildNPM("1.*").toString());
+        assertEquals(">=1.0.0 <2.0.0", Requirement.buildNPM("1.x").toString());
+        assertEquals("=1.0.0", Requirement.buildNPM("1.0.0").toString());
+        assertEquals("=1.0.0", Requirement.buildNPM("=1.0.0").toString());
+        assertEquals("=1.0.0", Requirement.buildNPM("v1.0.0").toString());
+        assertEquals("<1.0.0", Requirement.buildNPM("<1.0.0").toString());
+        assertEquals("<=1.0.0", Requirement.buildNPM("<=1.0.0").toString());
+        assertEquals(">1.0.0", Requirement.buildNPM(">1.0.0").toString());
+        assertEquals(">=1.0.0", Requirement.buildNPM(">=1.0.0").toString());
+        assertEquals(">=1.0.0 <1.1.0", Requirement.buildNPM("~1.0.0").toString());
+        assertEquals(">=1.0.0 <2.0.0", Requirement.buildNPM("^1.0.0").toString());
+        assertEquals(">=5.0.0 <=7.2.3 || >=1.0.0 <2.0.0 || >=2.5.0", Requirement.buildNPM("1.x || >=2.5.0 || 5.0.0 - 7.2.3").toString());
+
+        assertEquals(">=1.2.0 <1.3.0", Requirement.buildCocoapods("~>1.2.0").toString());
+
+        assertEquals(">=1.0.0 <=2.0.0", Requirement.buildIvy("[1.0,2.0]").toString());
+        assertEquals(">=1.0.0 <2.0.0", Requirement.buildIvy("[1.0,2.0[").toString());
+        assertEquals(">1.0.0 <=2.0.0", Requirement.buildIvy("]1.0,2.0]").toString());
+        assertEquals(">1.0.0 <2.0.0", Requirement.buildIvy("]1.0,2.0[").toString());
+        assertEquals(">=1.0.0", Requirement.buildIvy("[1.0,)").toString());
+        assertEquals(">1.0.0", Requirement.buildIvy("]1.0,)").toString());
+        assertEquals("<=2.0.0", Requirement.buildIvy("(,2.0]").toString());
+        assertEquals("<2.0.0", Requirement.buildIvy("(,2.0[").toString());
+    }
+
     private static void assertIsRange(Requirement requirement, String version, Range.RangeOperator operator) {
         assertNull(requirement.req1);
         assertNull(requirement.op);


### PR DESCRIPTION
This PR adds pretty `toString()` representations for the `Range` and `Requirement` classes.

Instead of a relatively abstract representation for `Range#toString()` and `Requirement#toString()`, these methods now return a representation which is in turn again a valid range or version expression.

Example for `Range#toString()`:

* Before: "(EQ, 1.2.3)"
* After: "=1.2.3"

Examples for `Requirement#toString()`:

* Before: "Requirement{(EQ, 1.2.3)}"
* After: "=1.2.3"

* Before: "Requirement{(EQ, 1.2.3) OR (LT, 2.0.0)}"
* After: "=1.2.3 || <2.0.0"