### PR TITLE
Implement equals() and hashCode() for Range and Requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,10 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <testSource>1.6</testSource>
-                    <testTarget>1.6</testTarget>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <testSource>1.7</testSource>
+                    <testTarget>1.7</testTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/vdurmont/semver4j/Range.java
+++ b/src/main/java/com/vdurmont/semver4j/Range.java
@@ -1,5 +1,7 @@
 package com.vdurmont.semver4j;
 
+import java.util.Objects;
+
 // TODO doc
 public class Range {
     protected final Semver version;
@@ -33,6 +35,18 @@ public class Range {
         }
 
         throw new RuntimeException("Code error. Unknown RangeOperator: " + this.op); // Should never happen
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Range)) return false;
+        Range range = (Range) o;
+        return Objects.equals(version, range.version) &&
+                op == range.op;
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(version, op);
     }
 
     @Override public String toString() {

--- a/src/main/java/com/vdurmont/semver4j/Requirement.java
+++ b/src/main/java/com/vdurmont/semver4j/Requirement.java
@@ -584,6 +584,20 @@ public class Requirement {
         return res;
     }
 
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Requirement)) return false;
+        Requirement that = (Requirement) o;
+        return Objects.equals(range, that.range) &&
+                Objects.equals(req1, that.req1) &&
+                op == that.op &&
+                Objects.equals(req2, that.req2);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(range, req1, op, req2);
+    }
+
     @Override public String toString() {
         if (this.range != null) {
             return "Requirement{" + this.range + "}";

--- a/src/test/java/com/vdurmont/semver4j/RangeTest.java
+++ b/src/test/java/com/vdurmont/semver4j/RangeTest.java
@@ -5,7 +5,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
@@ -60,5 +62,23 @@ public class RangeTest {
         assertTrue(range.isSatisfiedBy("1.2.3"));
         assertFalse(range.isSatisfiedBy("1.2.2"));
         assertTrue(range.isSatisfiedBy("1.2.4"));
+    }
+
+    @Test public void testEquals() {
+        Range range = new Range("1.2.3", Range.RangeOperator.EQ);
+
+        assertEquals(range, range);
+        assertNotEquals(range, null);
+        assertNotEquals(range, "string");
+        assertNotEquals(range, new Range("1.2.3", Range.RangeOperator.GTE));
+        assertNotEquals(range, new Range("1.2.4", Range.RangeOperator.EQ));
+    }
+
+    @Test public void testHashCode() {
+        Range range = new Range("1.2.3", Range.RangeOperator.EQ);
+
+        assertEquals(range.hashCode(), range.hashCode());
+        assertNotEquals(range.hashCode(), new Range("1.2.3", Range.RangeOperator.GTE).hashCode());
+        assertNotEquals(range.hashCode(), new Range("1.2.4", Range.RangeOperator.EQ).hashCode());
     }
 }

--- a/src/test/java/com/vdurmont/semver4j/RequirementTest.java
+++ b/src/test/java/com/vdurmont/semver4j/RequirementTest.java
@@ -7,6 +7,7 @@ import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -403,6 +404,34 @@ public class RequirementTest {
         assertNull(req.op);
         assertEquals(Range.RangeOperator.GTE, req.range.op);
         assertTrue(req.range.version.isEquivalentTo("1.0.0"));
+    }
+
+    @Test public void testEquals() {
+        Requirement requirement = Requirement.buildStrict("1.2.3");
+
+        assertEquals(requirement, requirement);
+        assertEquals(requirement, Requirement.buildStrict("1.2.3"));
+        assertEquals(requirement, Requirement.buildLoose("1.2.3"));
+        assertEquals(requirement, Requirement.buildNPM("=1.2.3"));
+        assertEquals(requirement, Requirement.buildIvy("1.2.3"));
+        assertEquals(requirement, Requirement.buildCocoapods("1.2.3"));
+        assertNotEquals(requirement, null);
+        assertNotEquals(requirement, "string");
+        assertNotEquals(requirement, Requirement.buildStrict("1.2.4"));
+        assertNotEquals(requirement, Requirement.buildNPM(">1.2.3"));
+    }
+
+    @Test public void testHashCode() {
+        Requirement requirement = Requirement.buildStrict("1.2.3");
+
+        assertEquals(requirement.hashCode(), requirement.hashCode());
+        assertEquals(requirement.hashCode(), Requirement.buildStrict("1.2.3").hashCode());
+        assertEquals(requirement.hashCode(), Requirement.buildLoose("1.2.3").hashCode());
+        assertEquals(requirement.hashCode(), Requirement.buildNPM("=1.2.3").hashCode());
+        assertEquals(requirement.hashCode(), Requirement.buildIvy("1.2.3").hashCode());
+        assertEquals(requirement.hashCode(), Requirement.buildCocoapods("1.2.3").hashCode());
+        assertNotEquals(requirement.hashCode(), Requirement.buildStrict("1.2.4").hashCode());
+        assertNotEquals(requirement.hashCode(), Requirement.buildNPM(">1.2.3").hashCode());
     }
 
     private static void assertIsRange(Requirement requirement, String version, Range.RangeOperator operator) {


### PR DESCRIPTION
If users want to compare instances of `Range` or `Requirement`, add them to a `Set`, or add them as keys to a `Map`, the `Object#equals()` and `Object#hashCode()` methods must be overridden to enable the expected behavior.