### PR TITLE
Enable adoption in modularized Java 9 projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,18 @@
                     <testTarget>1.7</testTarget>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.vdurmont.semver4j</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
Currently, this project can't be used in a modularized Java 9 (or greater) project, because it cannot be required as a module:
```
module foo {

    requires org.apache.commons.collections4;
    requires com.vdurmont.semver4j; // Does not compile!

}
```
The easiest way to solve this is to add an automatic module name as I've done in this PR. There's also another way that involves the creation of a `module-info.java` file, but it also requires the adoption of Java 9 in this project, which is unwise IMO.

More info here: https://blog.joda.org/2018/03/jpms-negative-benefits.html