### PR TITLE
Check there are no more than 3 levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.0
+- Check there are max 3 levels in a version
+
 ## 3.1.0
 
 - Fix NPM loose comparisons (thanks @kmck)

--- a/src/main/java/com/vdurmont/semver4j/Semver.java
+++ b/src/main/java/com/vdurmont/semver4j/Semver.java
@@ -55,6 +55,10 @@ public class Semver implements Comparable<Semver> {
                 mainTokens = tokens[0].split("\\.");
             }
 
+            if (mainTokens.length > 3) {
+                throw new SemverException("There should be no more than 3 levels: " + value);
+            }
+
             try {
                 this.major = Integer.valueOf(mainTokens[0]);
             } catch (NumberFormatException e) {

--- a/src/test/java/com/vdurmont/semver4j/SemverTest.java
+++ b/src/test/java/com/vdurmont/semver4j/SemverTest.java
@@ -367,4 +367,8 @@ public class SemverTest {
         assertFalse(new Semver("0.1.2+sHa.0nSFGKjkjsdf").isStable());
         assertFalse(new Semver("0.1.2").isStable());
     }
+
+    @Test(expected = SemverException.class) public void maxLevels_test() {
+        new Semver("1.2.3.4");
+    }
 }


### PR DESCRIPTION
I believe https://semver.org specifies no more than three levels (major, minor and patch). This is a backwards incompatible change, hence I bumped the major version for semver4j as well.